### PR TITLE
Address Deprecation Warning

### DIFF
--- a/lib/devise/eventable/models/eventable.rb
+++ b/lib/devise/eventable/models/eventable.rb
@@ -24,7 +24,8 @@ module Devise
         #end
       end
 
-      if Devise.activerecord51?
+      is_active_record51 = defined?(ActiveRecord) && ActiveRecord.gem_version >= Gem::Version.new("5.1.x")
+      if is_active_record51
         def fire_events_on_model_update
           Devise.fire_event(:password_change, { record: self } ) if saved_change_to_encrypted_password?
           Devise.fire_event(:password_reset_sent, { record: self } ) if saved_change_to_reset_password_token? && !saved_change_to_encrypted_password?

--- a/lib/devise/eventable/version.rb
+++ b/lib/devise/eventable/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module Eventable
-    VERSION = "0.1.4"
+    VERSION = "0.1.5"
   end
 end


### PR DESCRIPTION
```ruby
    deprecator.warn <<-DEPRECATION.strip_heredoc
      [Devise] `Devise.activerecord51?` is deprecated and will be removed in the next major version.
      It is a non-public method that's no longer used internally, but that other libraries have been relying on.
    DEPRECATION
    defined?(ActiveRecord) && ActiveRecord.gem_version >= Gem::Version.new("5.1.x")
```
## Changes 

- From the main devise gem, they have been keeping this method around just for legacy usages and it will be removed in the future. I'm merely updating the library to stop relying on it and execute the check directly.
- Bumped version